### PR TITLE
Use 8 chars for the git sha

### DIFF
--- a/src/index_page.rs
+++ b/src/index_page.rs
@@ -19,7 +19,7 @@ impl IndexTemplate {
 
         Self {
             git_rev: env::var("OPENSHIFT_BUILD_COMMIT")
-                .unwrap_or(format!("{:.6}", String::from(GIT_REV)))
+                .unwrap_or(format!("{:.8}", String::from(GIT_REV)))
                 .to_string(),
             tz_json,
         }


### PR DESCRIPTION
GitHub show 7, GitLab show 8, Gitea show 10. So 8 seems like a middleground.