### PR TITLE
Build the docker image every night, or if there is a push

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: '40 3 * * *'
 
 jobs:
   build:
@@ -25,7 +27,7 @@ jobs:
           export DATE=$(date +%Y%m%d)
           export IMAGE=$GITHUB_REPOSITORY
           podman build . --env GIT_REV=$GITHUB_SHA --tag $REGISTRY/$IMAGE:$DATE --tag $REGISTRY/$IMAGE:latest
-          if [ ${GITHUB_REF} == 'refs/heads/main' -a ${GITHUB_EVENT_NAME} == 'push' ]; then
+          if [[ ${GITHUB_REF} == 'refs/heads/main' &&  ${GITHUB_EVENT_NAME} == 'push' ]] || [[ ${GITHUB_EVENT_NAME} == 'schedule' ]]; then
             echo $PASSWORD | podman login $REGISTRY -u $GITHUB_REPOSITORY_OWNER --password-stdin
             podman push $REGISTRY/$IMAGE:latest
             podman push $REGISTRY/$IMAGE:$DATE


### PR DESCRIPTION
Since Github has complicated rules about what can trigger workflow or not, let's just use a good old fashioned cron. Since dependabot and/or renovatebot count as activity, it should prevent the automated disabling of the build.