### PR TITLE
Revert to using the token and not a PAT

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,9 +1,9 @@
 name: Auto-merge Dependabot
 on: pull_request
 
-#permissions:
-#  pull-requests: write
-#  contents: write
+permissions:
+  pull-requests: write
+  contents: write
 
 jobs:
   automerge:
@@ -15,5 +15,5 @@ jobs:
       - name: Enable automerge
         run: gh pr merge --rebase --auto  ${PR_NUMBER}
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Since the switch was made to be able to trigger docker build, but this was now moved to a cron job, this is not needed.